### PR TITLE
Date -> endDate

### DIFF
--- a/components/date_select/DateRangeSelect.js
+++ b/components/date_select/DateRangeSelect.js
@@ -61,7 +61,7 @@ const factory = (Trigger, SelectInput, DateRange) => {
       }
 
       if ('endDate' in nextProps) {
-        this.setState({ date: nextProps.endDate });
+        this.setState({ endDate: nextProps.endDate });
       }
 
       if (nextProps.ranges !== this.props.ranges) {


### PR DESCRIPTION
这边有笔误，date应该是endDate，否则日期范围选择器，会 永远显示成当前日期。
![2017-09-11 10 56 03](https://user-images.githubusercontent.com/4576326/30256798-decb69be-96df-11e7-8210-ff7aaf73b178.png)
